### PR TITLE
Add depth-first search

### DIFF
--- a/metaedia.py
+++ b/metaedia.py
@@ -42,7 +42,7 @@ def get_first_website_link(url, linkToSearchFor):
         if href == linkToSearchFor:
             firstLink = href
             break
-            
+
     query_urls.append(firstLink)
     return firstLink
 
@@ -50,15 +50,15 @@ def crawl(url, url2, max_urls):
     if max_urls == 0:
         print(f"{RED}[!] Articles aren't connected. {RESET}")
         return
-        
+
     link = get_first_website_link(url, url2)
-    
+
     if link == url2:
         print(f"{GREEN}[!] Article connection found! {RESET}")
         for url in query_urls:
             print(f"- {url}")
         return
-        
+
     crawl(link, url2, max_urls-1)
 
 if __name__ == "__main__":
@@ -68,13 +68,13 @@ if __name__ == "__main__":
     parser.add_argument("article_b", help="Article name B.")
     parser.add_argument("-w", "--wiki-source", help="", default="https://de.wikipedia.org/wiki/", type=str)
     parser.add_argument("-m", "--max-urls", help="Number of max URLs to crawl.", default=50, type=int)
-    
+
     args = parser.parse_args()
     wiki_source = args.wiki_source
     article_a = wiki_source + args.article_a
     article_b = wiki_source + args.article_b
     max_urls = args.max_urls
-    
+
     internal_urls.add(article_a)
     query_urls.append(article_a)
 


### PR DESCRIPTION
As discussed, time complexity goes from O(n) to O(n^2) w.r.t. max_urls, but it allows backtracking, i.e. to use different links than just the first. The practical time it takes to find paths between sites appears almost unchanged in reality, 1.92s vs 1.98s.

Breadth-first would most likely find shorter paths, but also take a lot more requests - for this to be efficient you'd need to download Wikipedia locally and query it on-device.